### PR TITLE
[fixed #171532646]ユーザーは終了後もチャットログの閲覧ができる

### DIFF
--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -11,29 +11,31 @@
   <%= render @messages %>
 </div>
 
-<div>
-  <%= form_with model: [@room, @message], local: true do |f| %>
-    <div>
-      <%= f.label :body, "内容" %>
-      <%= f.text_area :body %>
-    </div>
+<% if @room.end_time > Time.zone.now %>
+  <div>
+    <%= form_with model: [@room, @message], local: true do |f| %>
+      <div>
+        <%= f.label :body, "内容" %>
+        <%= f.text_area :body %>
+      </div>
 
-    <div>
-      <% @message.errors.full_messages.each do |message| %>
-        <p><%= message %></p>
-      <% end %>
-    </div>
+      <div>
+        <% @message.errors.full_messages.each do |message| %>
+          <p><%= message %></p>
+        <% end %>
+      </div>
 
-    <div>
-      <%= f.submit %>
-    </div>
-  <% end %>
-</div>
+      <div>
+        <%= f.submit %>
+      </div>
+    <% end %>
+  </div>
 
-<script>
-  window.addEventListener('turbolinks:load',function(){
-  const interval = 60000;
+  <script>
+    window.addEventListener('turbolinks:load',function(){
+    const interval = 60000;
 
-  setInterval('location.reload()',interval);
-  });
-</script>
+    setInterval('location.reload()',interval);
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171532646
現状で、終了後もメンバーのみがログを閲覧できるようになっているため、
終了した部屋での投稿フォーム表示と自動リロードをしないように設定